### PR TITLE
Crafting system initial implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "laravel": {
       "providers": [
         "PbbgEngine\\Item\\ItemServiceProvider",
-        "PbbgEngine\\Item\\QuestServiceProvider"
+        "PbbgEngine\\Item\\QuestServiceProvider",
+        "PbbgEngine\\Item\\CraftingServiceProvider"
       ]
     }
   },

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "laravel": {
       "providers": [
         "PbbgEngine\\Item\\ItemServiceProvider",
-        "PbbgEngine\\Item\\QuestServiceProvider",
-        "PbbgEngine\\Item\\CraftingServiceProvider"
+        "PbbgEngine\\Quest\\QuestServiceProvider",
+        "PbbgEngine\\Crafting\\CraftingServiceProvider"
       ]
     }
   },

--- a/database/migrations/create_crafting_tables.php
+++ b/database/migrations/create_crafting_tables.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('blueprints', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->morphs('model');
+            $table->timestamps();
+        });
+
+        Schema::create('components', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('blueprint_id');
+            $table->morphs('model');
+            $table->timestamps();
+            $table->foreign('blueprint_id')->references('id')->on('blueprints');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('components');
+        Schema::dropIfExists('blueprints');
+    }
+};

--- a/database/migrations/create_crafting_tables.php
+++ b/database/migrations/create_crafting_tables.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->morphs('model');
+            $table->json('data')->nullable();
             $table->timestamps();
         });
 
@@ -24,6 +25,7 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('blueprint_id');
             $table->morphs('model');
+            $table->json('data')->nullable();
             $table->timestamps();
             $table->foreign('blueprint_id')->references('id')->on('blueprints');
         });

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,5 +16,8 @@
         <testsuite name="Quest test suite">
             <directory>tests/Quest</directory>
         </testsuite>
+        <testsuite name="Crafting test suite">
+            <directory>tests/Crafting</directory>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Crafting/Actions/Action.php
+++ b/src/Crafting/Actions/Action.php
@@ -5,15 +5,18 @@ declare(strict_types=1);
 namespace PbbgEngine\Crafting\Actions;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\MessageBag;
 use PbbgEngine\Crafting\Models\Component;
 
-interface Action
+abstract class Action
 {
+    public function __construct(protected MessageBag $messages) {}
+
     /**
      * Executes an action after all component conditions are satisfied.
      *
      * This method may define any additional actions that need to be performed
      * after crafting conditions are met, and before blueprint building occurs.
      */
-    public function run(Model $model, Component $component): void;
+    abstract public function run(Model $model, Component $component): void;
 }

--- a/src/Crafting/Actions/Action.php
+++ b/src/Crafting/Actions/Action.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Models\Component;
+
+interface Action
+{
+    public function run(Model $model, Component $component): void;
+}

--- a/src/Crafting/Actions/Action.php
+++ b/src/Crafting/Actions/Action.php
@@ -9,5 +9,11 @@ use PbbgEngine\Crafting\Models\Component;
 
 interface Action
 {
+    /**
+     * Executes an action after all component conditions are satisfied.
+     *
+     * This method may define any additional actions that need to be performed
+     * after crafting conditions are met, and before blueprint building occurs.
+     */
     public function run(Model $model, Component $component): void;
 }

--- a/src/Crafting/Builders/Builder.php
+++ b/src/Crafting/Builders/Builder.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Builders;
+
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Models\Blueprint;
+
+interface Builder
+{
+    public function build(Model $model, Blueprint $blueprint): bool;
+}

--- a/src/Crafting/Builders/Builder.php
+++ b/src/Crafting/Builders/Builder.php
@@ -5,14 +5,17 @@ declare(strict_types=1);
 namespace PbbgEngine\Crafting\Builders;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\MessageBag;
 use PbbgEngine\Crafting\Models\Blueprint;
 
-interface Builder
+abstract class Builder
 {
+    public function __construct(protected MessageBag $messages) {}
+
     /**
      * Builds the blueprint.
      *
      * The model is typically the owner of what is created by the blueprint.
      */
-    public function build(Model $model, Blueprint $blueprint): bool;
+    abstract public function build(Model $model, Blueprint $blueprint): void;
 }

--- a/src/Crafting/Builders/Builder.php
+++ b/src/Crafting/Builders/Builder.php
@@ -9,5 +9,10 @@ use PbbgEngine\Crafting\Models\Blueprint;
 
 interface Builder
 {
+    /**
+     * Builds the blueprint.
+     *
+     * The model is typically the owner of what is created by the blueprint.
+     */
     public function build(Model $model, Blueprint $blueprint): bool;
 }

--- a/src/Crafting/Conditions/Condition.php
+++ b/src/Crafting/Conditions/Condition.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace PbbgEngine\Crafting\Conditions;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\MessageBag;
 use PbbgEngine\Crafting\Models\Component;
 
-interface Condition
+abstract class Condition
 {
+    public function __construct(protected MessageBag $messages) {}
+
     /**
      * Checks if the given model satisfies the condition for the provided component.
      */
-    public function passes(Model $model, Component $component): bool;
+    abstract public function passes(Model $model, Component $component): void;
 }

--- a/src/Crafting/Conditions/Condition.php
+++ b/src/Crafting/Conditions/Condition.php
@@ -9,5 +9,8 @@ use PbbgEngine\Crafting\Models\Component;
 
 interface Condition
 {
+    /**
+     * Checks if the given model satisfies the condition for the provided component.
+     */
     public function passes(Model $model, Component $component): bool;
 }

--- a/src/Crafting/Conditions/Condition.php
+++ b/src/Crafting/Conditions/Condition.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Conditions;
+
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Models\Component;
+
+interface Condition
+{
+    public function passes(Model $model, Component $component): bool;
+}

--- a/src/Crafting/CraftingService.php
+++ b/src/Crafting/CraftingService.php
@@ -19,7 +19,7 @@ class CraftingService
                 case Item::class:
                     // todo: create per model handlers
                     if (!method_exists($model, 'items')) {
-                        throw new Exception("{$this->model} cannot have items");
+                        throw new Exception("{$model} cannot have items");
                     }
                     if ($model->items()->where('item_id', $component->model_id)->count() == 0) {
                         return false;
@@ -27,7 +27,7 @@ class CraftingService
                     break;
                 case Quest::class:
                     if (!method_exists($model, 'quests')) {
-                        throw new Exception("{$this->model} cannot have quests");
+                        throw new Exception("{$model} cannot have quests");
                     }
                     $hasCompletedQuest = $model->quests()
                             ->where('quest_id', $component->model_id)

--- a/src/Crafting/CraftingService.php
+++ b/src/Crafting/CraftingService.php
@@ -10,25 +10,38 @@ use PbbgEngine\Crafting\Actions\Action;
 use PbbgEngine\Crafting\Builders\Builder;
 use PbbgEngine\Crafting\Conditions\Condition;
 use PbbgEngine\Crafting\Models\Blueprint;
+use PbbgEngine\Crafting\Models\Component;
 
 class CraftingService
 {
     /**
+     * Stores component condition handlers per model type.
+     * Each component of a blueprint must pass to allow the crafting to occur.
+     *
      * @var array<string, string>
      */
     public array $conditions = [];
 
     /**
+     * Stores component action runners per model type.
+     * Action runners will run for each component of the blueprint once all conditions pass.
+     *
      * @var array<string, string>
      */
     public array $actions = [];
 
     /**
+     * Stores blueprint builders per model type.
+     * Runs after the action runners when all component conditions are met.
+     *
      * @var array<string, string>
      */
     public array $builders = [];
 
     /**
+     * Checks whether the required conditions for each component in the
+     * blueprint are satisfied to be able to craft the given blueprint.
+     *
      * @throws Exception
      */
     public function canCraft(Model $model, Blueprint $blueprint): bool
@@ -50,6 +63,11 @@ class CraftingService
     }
 
     /**
+     * Executes the crafting process for the provided model and blueprint.
+     *
+     * Runs optional actions for each component and builds the final result
+     * using the specified builder for the blueprint model type.
+     *
      * @throws Exception
      */
     public function craft(Model $model, Blueprint $blueprint): bool
@@ -59,34 +77,54 @@ class CraftingService
         }
 
         // ensure builder exists for the blueprint before running actions
-        if (!isset($this->builders[$blueprint->model_type])) {
-            throw new Exception("blueprint builder does not exist for model: $blueprint->model_type");
-        }
-        if (!class_exists($this->builders[$blueprint->model_type])) {
-            throw new Exception("specified component action runner does not exist for model: $blueprint->model_type");
-        }
-        if (!is_subclass_of($this->builders[$blueprint->model_type], Builder::class)) {
-            throw new Exception("invalid component action runner: $blueprint->model_type");
-        }
+        $this->validateBuilder($blueprint->model_type);
 
         foreach ($blueprint->components as $component) {
-            if (!isset($this->actions[$component->model_type])) {
-                // actions are optional
-                continue;
-            }
-            if (!class_exists($this->actions[$component->model_type])) {
-                throw new Exception("specified component action runner does not exist for model: $component->model_type");
-            }
-            if (!is_subclass_of($this->actions[$component->model_type], Action::class)) {
-                throw new Exception("invalid component action runner: $component->model_type");
-            }
-            $handler = new $this->actions[$component->model_type];
-            $handler->run($model, $component);
+            $this->runComponentAction($model, $component);
         }
 
+        /** @var Builder $builder */
         $builder = new $this->builders[$blueprint->model_type];
         $builder->build($model, $blueprint);
 
         return true;
+    }
+
+    /**
+     * Validates if the builder for the provided model is valid.
+     *
+     * This method is used to prevent running actions if
+     * the blueprint model cannot be crafted.
+     */
+    private function validateBuilder(string $model): void
+    {
+        if (!isset($this->builders[$model])) {
+            throw new Exception("blueprint builder does not exist for model: $model");
+        }
+        if (!class_exists($this->builders[$model])) {
+            throw new Exception("specified component action runner does not exist for model: $model");
+        }
+        if (!is_subclass_of($this->builders[$model], Builder::class)) {
+            throw new Exception("invalid component action runner: $model");
+        }
+    }
+
+    /**
+     * Runs the component action for the provided component if it exists.
+     */
+    private function runComponentAction(Model $model, Component $component): void
+    {
+        if (!isset($this->actions[$component->model_type])) {
+            // actions are optional
+            return;
+        }
+        if (!class_exists($this->actions[$component->model_type])) {
+            throw new Exception("specified component action runner does not exist for model: $component->model_type");
+        }
+        if (!is_subclass_of($this->actions[$component->model_type], Action::class)) {
+            throw new Exception("invalid component action runner: $component->model_type");
+        }
+        $handler = new $this->actions[$component->model_type];
+        $handler->run($model, $component);
     }
 }

--- a/src/Crafting/CraftingService.php
+++ b/src/Crafting/CraftingService.php
@@ -10,6 +10,7 @@ use PbbgEngine\Crafting\Actions\Action;
 use PbbgEngine\Crafting\Builders\Builder;
 use PbbgEngine\Crafting\Conditions\Condition;
 use PbbgEngine\Crafting\Exceptions\HandlerDoesNotExist;
+use PbbgEngine\Crafting\Exceptions\HasNoComponents;
 use PbbgEngine\Crafting\Exceptions\InvalidHandler;
 use PbbgEngine\Crafting\Models\Blueprint;
 use PbbgEngine\Crafting\Models\Component;
@@ -48,6 +49,10 @@ class CraftingService
      */
     public function canCraft(Model $model, Blueprint $blueprint): bool
     {
+        if ($blueprint->components->count() === 0) {
+            throw new HasNoComponents($blueprint);
+        }
+
         foreach ($blueprint->components as $component) {
             if (!isset($this->conditions[$component->model_type]) || !class_exists($this->conditions[$component->model_type])) {
                 throw new HandlerDoesNotExist("component condition handler does not exist for model: $component->model_type");

--- a/src/Crafting/CraftingService.php
+++ b/src/Crafting/CraftingService.php
@@ -6,6 +6,8 @@ namespace PbbgEngine\Crafting;
 
 use Exception;
 use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Actions\Action;
+use PbbgEngine\Crafting\Builders\Builder;
 use PbbgEngine\Crafting\Conditions\Condition;
 use PbbgEngine\Crafting\Models\Blueprint;
 
@@ -16,6 +18,19 @@ class CraftingService
      */
     public array $conditions = [];
 
+    /**
+     * @var array<string, string>
+     */
+    public array $actions = [];
+
+    /**
+     * @var array<string, string>
+     */
+    public array $builders = [];
+
+    /**
+     * @throws Exception
+     */
     public function canCraft(Model $model, Blueprint $blueprint): bool
     {
         foreach ($blueprint->components as $component) {
@@ -30,6 +45,47 @@ class CraftingService
                 return false;
             }
         }
+
+        return true;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function craft(Model $model, Blueprint $blueprint): bool
+    {
+        if (!$this->canCraft($model, $blueprint)) {
+            return false;
+        }
+
+        // ensure builder exists for the blueprint before running actions
+        if (!isset($this->builders[$blueprint->model_type])) {
+            throw new Exception("blueprint builder does not exist for model: $blueprint->model_type");
+        }
+        if (!class_exists($this->builders[$blueprint->model_type])) {
+            throw new Exception("specified component action runner does not exist for model: $blueprint->model_type");
+        }
+        if (!is_subclass_of($this->builders[$blueprint->model_type], Builder::class)) {
+            throw new Exception("invalid component action runner: $blueprint->model_type");
+        }
+
+        foreach ($blueprint->components as $component) {
+            if (!isset($this->actions[$component->model_type])) {
+                // actions are optional
+                continue;
+            }
+            if (!class_exists($this->actions[$component->model_type])) {
+                throw new Exception("specified component action runner does not exist for model: $component->model_type");
+            }
+            if (!is_subclass_of($this->actions[$component->model_type], Action::class)) {
+                throw new Exception("invalid component action runner: $component->model_type");
+            }
+            $handler = new $this->actions[$component->model_type];
+            $handler->run($model, $component);
+        }
+
+        $builder = new $this->builders[$blueprint->model_type];
+        $builder->build($model, $blueprint);
 
         return true;
     }

--- a/src/Crafting/CraftingService.php
+++ b/src/Crafting/CraftingService.php
@@ -25,6 +25,18 @@ class CraftingService
                         return false;
                     }
                     break;
+                case Quest::class:
+                    if (!method_exists($model, 'quests')) {
+                        throw new Exception("{$this->model} cannot have quests");
+                    }
+                    $hasCompletedQuest = $model->quests()
+                            ->where('quest_id', $component->model_id)
+                            ->whereNotNull('completed_at')
+                            ->count() > 0;
+                    if (!$hasCompletedQuest) {
+                        return false;
+                    }
+                    break;
                 default:
                     throw new Exception("invalid crafting component model type: $component->model_type");
             }

--- a/src/Crafting/CraftingService.php
+++ b/src/Crafting/CraftingService.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Models\Blueprint;
+use PbbgEngine\Item\Models\Item;
+use PbbgEngine\Quest\Models\Quest;
+
+class CraftingService
+{
+    public function canCraft(Model $model, Blueprint $blueprint): bool
+    {
+        foreach ($blueprint->components as $component) {
+            switch ($component->model_type) {
+                case Item::class:
+                    // todo: create per model handlers
+                    if (!method_exists($model, 'items')) {
+                        throw new Exception("{$this->model} cannot have items");
+                    }
+                    if ($model->items()->where('item_id', $component->model_id)->count() == 0) {
+                        return false;
+                    }
+                    break;
+                default:
+                    throw new Exception("invalid crafting component model type: $component->model_type");
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Crafting/CraftingServiceProvider.php
+++ b/src/Crafting/CraftingServiceProvider.php
@@ -17,6 +17,14 @@ class CraftingServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(CraftingService::class);
+    }
+
+    /**
      * Publish the crafting table migrations.
      */
     public function publishMigrations(): void

--- a/src/Crafting/CraftingServiceProvider.php
+++ b/src/Crafting/CraftingServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting;
+
+use Illuminate\Support\ServiceProvider;
+
+class CraftingServiceProvider extends ServiceProvider
+{
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        $this->publishMigrations();
+    }
+
+    /**
+     * Publish the crafting table migrations.
+     */
+    public function publishMigrations(): void
+    {
+        $timestamp = date('Y_m_d_His');
+
+        $this->publishes([
+            __DIR__.'/../../database/migrations/create_crafting_tables.php' => $this->app->databasePath("migrations/{$timestamp}_create_crafting_tables.php")
+        ]);
+    }
+}

--- a/src/Crafting/Exceptions/HandlerDoesNotExist.php
+++ b/src/Crafting/Exceptions/HandlerDoesNotExist.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Exceptions;
+
+use Exception;
+
+class HandlerDoesNotExist extends Exception
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Crafting/Exceptions/HasNoComponents.php
+++ b/src/Crafting/Exceptions/HasNoComponents.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Exceptions;
+
+use Exception;
+use PbbgEngine\Crafting\Models\Blueprint;
+
+class HasNoComponents extends Exception
+{
+    public function __construct(Blueprint $blueprint)
+    {
+        parent::__construct("attempted to craft blueprint $blueprint->id which has no components");
+    }
+}

--- a/src/Crafting/Exceptions/InvalidHandler.php
+++ b/src/Crafting/Exceptions/InvalidHandler.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Exceptions;
+
+use Exception;
+
+class InvalidHandler extends Exception
+{
+    public function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/Crafting/Models/Blueprint.php
+++ b/src/Crafting/Models/Blueprint.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $model_type
+ * @property int $model_id
+ */
+class Blueprint extends Model
+{
+    protected $fillable = ['name', 'model_type', 'model_id'];
+
+    /**
+     * Get the components of the blueprint.
+     *
+     * @return HasMany<Component>
+     */
+    public function components(): HasMany
+    {
+        return $this->hasMany(Component::class);
+    }
+
+    /**
+     * Get the model is crafted using the blueprint.
+     *
+     * @return MorphTo<Model, Blueprint>
+     */
+    public function model(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/src/Crafting/Models/Blueprint.php
+++ b/src/Crafting/Models/Blueprint.php
@@ -4,19 +4,26 @@ declare(strict_types=1);
 
 namespace PbbgEngine\Crafting\Models;
 
+use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Collection;
 
 /**
  * @property int $id
  * @property string $name
  * @property string $model_type
  * @property int $model_id
+ * @property Collection $data
  */
 class Blueprint extends Model
 {
-    protected $fillable = ['name', 'model_type', 'model_id'];
+    protected $fillable = ['name', 'model_type', 'model_id', 'data'];
+
+    protected $casts = [
+        'data' => AsCollection::class,
+    ];
 
     /**
      * Get the components of the blueprint.

--- a/src/Crafting/Models/Component.php
+++ b/src/Crafting/Models/Component.php
@@ -4,19 +4,26 @@ declare(strict_types=1);
 
 namespace PbbgEngine\Crafting\Models;
 
+use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Collection;
 
 /**
  * @property int $id
  * @property int $blueprint_id
  * @property string $model_type
  * @property int $model_id
+ * @property Collection $data
  */
 class Component extends Model
 {
-    protected $fillable = ['blueprint_id', 'model_type', 'model_id'];
+    protected $fillable = ['blueprint_id', 'model_type', 'model_id', 'data'];
+
+    protected $casts = [
+        'data' => AsCollection::class,
+    ];
 
     /**
      * Get the blueprint of this component.

--- a/src/Crafting/Models/Component.php
+++ b/src/Crafting/Models/Component.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Crafting\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property int $id
+ * @property int $blueprint_id
+ * @property string $model_type
+ * @property int $model_id
+ */
+class Component extends Model
+{
+    protected $fillable = ['blueprint_id', 'model_type', 'model_id'];
+
+    /**
+     * Get the blueprint of this component.
+     *
+     * @return BelongsTo<Blueprint, Component>
+     */
+    public function blueprint(): BelongsTo
+    {
+        return $this->belongsTo(Blueprint::class);
+    }
+
+    /**
+     * Get the model that represents the component.
+     *
+     * @return MorphTo<Model, Component>
+     */
+    public function model(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/src/Item/Crafting/Actions/DeleteItem.php
+++ b/src/Item/Crafting/Actions/DeleteItem.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Item\Crafting\Actions;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Actions\Action;
+use PbbgEngine\Crafting\Models\Component;
+
+class DeleteItem implements Action
+{
+    public function run(Model $model, Component $component): void
+    {
+        if (!method_exists($model, 'items')) {
+            throw new Exception("{$model} cannot have items");
+        }
+
+        $item = $model->items()->where('item_id', $component->model_id)->first();
+        $item->delete();
+    }
+}

--- a/src/Item/Crafting/Actions/DeleteItem.php
+++ b/src/Item/Crafting/Actions/DeleteItem.php
@@ -6,10 +6,11 @@ namespace PbbgEngine\Item\Crafting\Actions;
 
 use Exception;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\MessageBag;
 use PbbgEngine\Crafting\Actions\Action;
 use PbbgEngine\Crafting\Models\Component;
 
-class DeleteItem implements Action
+class DeleteItem extends Action
 {
     public function run(Model $model, Component $component): void
     {

--- a/src/Item/Crafting/Builders/CraftItem.php
+++ b/src/Item/Crafting/Builders/CraftItem.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Item\Crafting\Builders;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Builders\Builder;
+use PbbgEngine\Crafting\Models\Blueprint;
+
+class CraftItem implements Builder
+{
+    public function build(Model $model, Blueprint $blueprint): bool
+    {
+        if (!method_exists($model, 'items')) {
+            throw new Exception("{$model} cannot have items");
+        }
+
+        $model->items()->create([
+            'model_type' => $model::class,
+            'item_id' => $blueprint->model_id,
+        ]);
+
+        return true;
+    }
+}

--- a/src/Item/Crafting/Builders/CraftItem.php
+++ b/src/Item/Crafting/Builders/CraftItem.php
@@ -9,9 +9,9 @@ use Illuminate\Database\Eloquent\Model;
 use PbbgEngine\Crafting\Builders\Builder;
 use PbbgEngine\Crafting\Models\Blueprint;
 
-class CraftItem implements Builder
+class CraftItem extends Builder
 {
-    public function build(Model $model, Blueprint $blueprint): bool
+    public function build(Model $model, Blueprint $blueprint): void
     {
         if (!method_exists($model, 'items')) {
             throw new Exception("{$model} cannot have items");
@@ -22,6 +22,6 @@ class CraftItem implements Builder
             'item_id' => $blueprint->model_id,
         ]);
 
-        return true;
+        $this->messages->add('success', "Crafted item {$blueprint->model->name}");
     }
 }

--- a/src/Item/Crafting/Conditions/HasItemToCraft.php
+++ b/src/Item/Crafting/Conditions/HasItemToCraft.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Item\Crafting\Conditions;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Conditions\Condition;
+use PbbgEngine\Crafting\Models\Component;
+
+class HasItemToCraft implements Condition
+{
+    public function passes(Model $model, Component $component): bool
+    {
+        if (!method_exists($model, 'items')) {
+            throw new Exception("{$model} cannot have items");
+        }
+
+        if ($model->items()->where('item_id', $component->model_id)->count() == 0) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Item/Crafting/Conditions/HasItemToCraft.php
+++ b/src/Item/Crafting/Conditions/HasItemToCraft.php
@@ -9,18 +9,16 @@ use Illuminate\Database\Eloquent\Model;
 use PbbgEngine\Crafting\Conditions\Condition;
 use PbbgEngine\Crafting\Models\Component;
 
-class HasItemToCraft implements Condition
+class HasItemToCraft extends Condition
 {
-    public function passes(Model $model, Component $component): bool
+    public function passes(Model $model, Component $component): void
     {
         if (!method_exists($model, 'items')) {
             throw new Exception("{$model} cannot have items");
         }
 
         if ($model->items()->where('item_id', $component->model_id)->count() == 0) {
-            return false;
+            $this->messages->add('errors', "Missing item {$component->model->name}");
         }
-
-        return true;
     }
 }

--- a/src/Item/ItemServiceProvider.php
+++ b/src/Item/ItemServiceProvider.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace PbbgEngine\Item;
 
 use Illuminate\Support\ServiceProvider;
+use PbbgEngine\Crafting\CraftingService;
+use PbbgEngine\Item\Crafting\Conditions\HasItemToCraft;
+use PbbgEngine\Item\Models\Item;
 
 class ItemServiceProvider extends ServiceProvider
 {
@@ -14,6 +17,10 @@ class ItemServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->publishMigrations();
+
+        // todo: only apply when crafting is enabled
+        $service = app(CraftingService::class);
+        $service->conditions[Item::class] = HasItemToCraft::class;
     }
 
     /**

--- a/src/Item/ItemServiceProvider.php
+++ b/src/Item/ItemServiceProvider.php
@@ -6,6 +6,8 @@ namespace PbbgEngine\Item;
 
 use Illuminate\Support\ServiceProvider;
 use PbbgEngine\Crafting\CraftingService;
+use PbbgEngine\Item\Crafting\Actions\DeleteItem;
+use PbbgEngine\Item\Crafting\Builders\CraftItem;
 use PbbgEngine\Item\Crafting\Conditions\HasItemToCraft;
 use PbbgEngine\Item\Models\Item;
 
@@ -21,6 +23,8 @@ class ItemServiceProvider extends ServiceProvider
         // todo: only apply when crafting is enabled
         $service = app(CraftingService::class);
         $service->conditions[Item::class] = HasItemToCraft::class;
+        $service->actions[Item::class] = DeleteItem::class;
+        $service->builders[Item::class] = CraftItem::class;
     }
 
     /**

--- a/src/Quest/Crafting/Builders/StartQuest.php
+++ b/src/Quest/Crafting/Builders/StartQuest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Quest\Crafting\Builders;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Builders\Builder;
+use PbbgEngine\Crafting\Models\Blueprint;
+
+class StartQuest extends Builder
+{
+    public function build(Model $model, Blueprint $blueprint): void
+    {
+        if (!method_exists($model, 'quests')) {
+            throw new Exception("{$model} cannot have quests");
+        }
+
+        if ($model->quests()->where('quest_id', $blueprint->model_id)->exists()) {
+            $this->messages->add('errors', "Already has quest {$blueprint->model->name}");
+            return;
+        }
+
+        $model->quests()->create([
+            'model_type' => $model::class,
+            'quest_id' => $blueprint->model_id,
+            'current_quest_stage_id' => $blueprint->model->initial_quest_stage_id,
+            'progress' => [],
+        ]);
+
+        $this->messages->add('success', "Started quest {$blueprint->model->name}");
+    }
+}

--- a/src/Quest/Crafting/Conditions/HasCompletedQuest.php
+++ b/src/Quest/Crafting/Conditions/HasCompletedQuest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Quest\Crafting\Conditions;
+
+use Exception;
+use Illuminate\Database\Eloquent\Model;
+use PbbgEngine\Crafting\Conditions\Condition;
+use PbbgEngine\Crafting\Models\Component;
+
+class HasCompletedQuest implements Condition
+{
+    public function passes(Model $model, Component $component): bool
+    {
+        if (!method_exists($model, 'quests')) {
+            throw new Exception("{$model} cannot have quests");
+        }
+
+        $hasCompletedQuest = $model->quests()
+                ->where('quest_id', $component->model_id)
+                ->whereNotNull('completed_at')
+                ->count() > 0;
+
+        if (!$hasCompletedQuest) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Quest/Crafting/Conditions/HasCompletedQuest.php
+++ b/src/Quest/Crafting/Conditions/HasCompletedQuest.php
@@ -9,9 +9,9 @@ use Illuminate\Database\Eloquent\Model;
 use PbbgEngine\Crafting\Conditions\Condition;
 use PbbgEngine\Crafting\Models\Component;
 
-class HasCompletedQuest implements Condition
+class HasCompletedQuest extends Condition
 {
-    public function passes(Model $model, Component $component): bool
+    public function passes(Model $model, Component $component): void
     {
         if (!method_exists($model, 'quests')) {
             throw new Exception("{$model} cannot have quests");
@@ -23,9 +23,7 @@ class HasCompletedQuest implements Condition
                 ->count() > 0;
 
         if (!$hasCompletedQuest) {
-            return false;
+            $this->messages->add('errors', "Quest {$component->model->name} has not been completed");
         }
-
-        return true;
     }
 }

--- a/src/Quest/QuestServiceProvider.php
+++ b/src/Quest/QuestServiceProvider.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace PbbgEngine\Quest;
 
 use Illuminate\Support\ServiceProvider;
+use PbbgEngine\Crafting\CraftingService;
+use PbbgEngine\Quest\Crafting\Conditions\HasCompletedQuest;
+use PbbgEngine\Quest\Models\Quest;
 
 class QuestServiceProvider extends ServiceProvider
 {
@@ -14,6 +17,10 @@ class QuestServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->publishMigrations();
+
+        // todo: only apply when crafting is enabled
+        $service = app(CraftingService::class);
+        $service->conditions[Quest::class] = HasCompletedQuest::class;
     }
 
     /**

--- a/src/Quest/QuestServiceProvider.php
+++ b/src/Quest/QuestServiceProvider.php
@@ -6,6 +6,7 @@ namespace PbbgEngine\Quest;
 
 use Illuminate\Support\ServiceProvider;
 use PbbgEngine\Crafting\CraftingService;
+use PbbgEngine\Quest\Crafting\Builders\StartQuest;
 use PbbgEngine\Quest\Crafting\Conditions\HasCompletedQuest;
 use PbbgEngine\Quest\Models\Quest;
 
@@ -21,6 +22,7 @@ class QuestServiceProvider extends ServiceProvider
         // todo: only apply when crafting is enabled
         $service = app(CraftingService::class);
         $service->conditions[Quest::class] = HasCompletedQuest::class;
+        $service->builders[Quest::class] = StartQuest::class;
     }
 
     /**

--- a/tests/Crafting/CraftingTest.php
+++ b/tests/Crafting/CraftingTest.php
@@ -5,14 +5,26 @@ declare(strict_types=1);
 namespace PbbgEngine\Tests\Crafting;
 
 use PbbgEngine\Crafting\CraftingService;
+use PbbgEngine\Crafting\CraftingServiceProvider;
 use PbbgEngine\Crafting\Models\Blueprint;
+use PbbgEngine\Item\ItemServiceProvider;
 use PbbgEngine\Item\Models\Item;
 use PbbgEngine\Quest\Models\Quest;
+use PbbgEngine\Quest\QuestServiceProvider;
 use PbbgEngine\Tests\TestCase;
 use Workbench\Database\Factories\UserFactory;
 
 class CraftingTest extends TestCase
 {
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ItemServiceProvider::class,
+            QuestServiceProvider::class,
+            CraftingServiceProvider::class,
+        ];
+    }
+
     public function testBlueprintHasComponents(): void
     {
         $dough = Item::create(['name' => 'Bread dough']);
@@ -70,7 +82,7 @@ class CraftingTest extends TestCase
             'model_id' => $water->id,
         ]);
 
-        $service = new CraftingService();
+        $service = app(CraftingService::class);
         $this->assertFalse($service->canCraft($user, $blueprint));
 
         $user->items()->create([

--- a/tests/Crafting/CraftingTest.php
+++ b/tests/Crafting/CraftingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PbbgEngine\Tests\Crafting;
+
+use PbbgEngine\Crafting\Models\Blueprint;
+use PbbgEngine\Item\Models\Item;
+use PbbgEngine\Tests\TestCase;
+
+class CraftingTest extends TestCase
+{
+    public function testBlueprintHasComponents(): void
+    {
+        $dough = Item::create(['name' => 'Bread dough']);
+        $blueprint = Blueprint::create([
+            'name' => 'Recipe: Bread dough',
+            'model_type' => $dough::class,
+            'model_id' => $dough->id],
+        );
+
+        $flour = Item::create(['name' => 'Pot of flour']);
+        $blueprint->components()->create([
+            'model_type' => $flour::class,
+            'model_id' => $flour->id,
+        ]);
+
+        $water = Item::create(['name' => 'Bucket of water']);
+        $blueprint->components()->create([
+            'model_type' => $water::class,
+            'model_id' => $water->id,
+        ]);
+
+        $this->assertModelExists($blueprint);
+        $this->assertModelExists($dough);
+        $this->assertModelExists($flour);
+        $this->assertModelExists($water);
+
+        $this->assertCount(2, $blueprint->components);
+
+        $this->assertEquals(
+            [$flour->id, $water->id],
+            $blueprint->components->pluck('model_id')->toArray(),
+        );
+    }
+}

--- a/tests/Crafting/CraftingTest.php
+++ b/tests/Crafting/CraftingTest.php
@@ -7,6 +7,7 @@ namespace PbbgEngine\Tests\Crafting;
 use PbbgEngine\Crafting\CraftingService;
 use PbbgEngine\Crafting\CraftingServiceProvider;
 use PbbgEngine\Crafting\Exceptions\HandlerDoesNotExist;
+use PbbgEngine\Crafting\Exceptions\HasNoComponents;
 use PbbgEngine\Crafting\Exceptions\InvalidHandler;
 use PbbgEngine\Crafting\Models\Blueprint;
 use PbbgEngine\Item\ItemServiceProvider;
@@ -154,6 +155,13 @@ class CraftingTest extends TestCase
         $this->assertThrows(function() use ($service, $user, $blueprint) {
             $service->canCraft($user, $blueprint);
         }, InvalidHandler::class);
+
+        $blueprint->components()->delete();
+        $blueprint->refresh();
+
+        $this->assertThrows(function() use ($service, $user, $blueprint) {
+            $service->canCraft($user, $blueprint);
+        }, HasNoComponents::class);
     }
 
     public function testCraft(): void

--- a/tests/Crafting/CraftingTest.php
+++ b/tests/Crafting/CraftingTest.php
@@ -49,7 +49,7 @@ class CraftingTest extends TestCase
 
     public function testModelCanCraft(): void
     {
-        $user = UserFactory::new()->create();
+        $user = UserFactory::new()->createOne();
 
         $dough = Item::create(['name' => 'Bread dough']);
         $blueprint = Blueprint::create([

--- a/tests/Crafting/CraftingTest.php
+++ b/tests/Crafting/CraftingTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace PbbgEngine\Tests\Crafting;
 
+use PbbgEngine\Crafting\CraftingService;
 use PbbgEngine\Crafting\Models\Blueprint;
 use PbbgEngine\Item\Models\Item;
+use PbbgEngine\Quest\Models\Quest;
 use PbbgEngine\Tests\TestCase;
+use Workbench\Database\Factories\UserFactory;
 
 class CraftingTest extends TestCase
 {
@@ -42,5 +45,46 @@ class CraftingTest extends TestCase
             [$flour->id, $water->id],
             $blueprint->components->pluck('model_id')->toArray(),
         );
+    }
+
+    public function testModelCanCraft(): void
+    {
+        $user = UserFactory::new()->create();
+
+        $dough = Item::create(['name' => 'Bread dough']);
+        $blueprint = Blueprint::create([
+            'name' => 'Recipe: Bread dough',
+            'model_type' => $dough::class,
+            'model_id' => $dough->id],
+        );
+
+        $flour = Item::create(['name' => 'Pot of flour']);
+        $blueprint->components()->create([
+            'model_type' => $flour::class,
+            'model_id' => $flour->id,
+        ]);
+
+        $water = Item::create(['name' => 'Bucket of water']);
+        $blueprint->components()->create([
+            'model_type' => $water::class,
+            'model_id' => $water->id,
+        ]);
+
+        $service = new CraftingService();
+        $this->assertFalse($service->canCraft($user, $blueprint));
+
+        $user->items()->create([
+            'model_type' => $user::class,
+            'item_id' => $flour->id
+        ]);
+
+        $this->assertFalse($service->canCraft($user, $blueprint));
+
+        $user->items()->create([
+            'model_type' => $user::class,
+            'item_id' => $water->id
+        ]);
+
+        $this->assertTrue($service->canCraft($user, $blueprint));
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PbbgEngine\Tests;
 
+use Illuminate\Support\MessageBag;
 use Orchestra\Testbench\TestCase as Orchestra;
 use function Orchestra\Testbench\workbench_path;
 
@@ -18,5 +19,15 @@ class TestCase extends Orchestra
     {
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->loadMigrationsFrom(workbench_path('database/migrations'));
+    }
+
+    public function assertHasErrors(MessageBag $messages): void
+    {
+        $this->assertTrue($messages->has('errors'));
+    }
+
+    public function assertHasNoErrors(MessageBag $messages): void
+    {
+        $this->assertFalse($messages->has('errors'));
     }
 }


### PR DESCRIPTION
This PR adds the initial implementation of the crafting system:

- Blueprints represent the recipes or instructions for crafting a specific entity
- Blueprints can have one or more components, which are individual prerequisites needed to craft
- Each component model type must have a `Condition` class that determines if the prerequisite is met (e.g. making sure they have the necessary items, resources, skill level, certain quest completed etc.)
- Component model types can optionally define an `Action` class to perform an action when all component conditions are met, before the crafting process occurs (e.g. consuming an required item before crafting the output, deducting x amount of a resourc etc.)
- Each blueprint model type must have a `Builder` class that determines how the blueprint output is generated (e.g. crafting an item, receiving x amount of a certain resource, starting a new quest etc.)
- The result of a crafting check or attempt will return an object containing the relevant error/success messages
- Added suitable default conditions, actions and builders for the item and quest systems. These can be overwritten

Implementation is subject to change